### PR TITLE
Link not aligned with image when measured size is different from mockup size

### DIFF
--- a/Balsamiq2html.class.php
+++ b/Balsamiq2html.class.php
@@ -288,8 +288,15 @@ class Balsamiq2html {
 					echo 'Processing '.$file_utf8.' ...<br />';
 					
 					$xml = simplexml_load_file($filepath);
+					$x = 0;
+					$y = 0;
+					$attrs = $xml->attributes();
+					if (isset($attrs['mockupW']) && isset($attrs['measuredW']) && isset($attrs['mockupH']) && isset($attrs['measuredH'])) {
+						$x = $attrs['mockupW'] - $attrs['measuredW'];
+						$y = $attrs['mockupH'] - $attrs['measuredH'];
+					}
 					
-					$links = $this->__crossControlList($xml->controls);
+					$links = $this->__crossControlList($xml->controls, $x, $y);
 					
 					usort($links, array('balsamiq2html','sort_list'));
 					


### PR DESCRIPTION
The coordinates of the link are relative to the full mockup. If the image is smaller like in this case the coordinates should be transposed

`<mockup version="1.0" skin="sketch" fontFace="Balsamiq Sans" measuredW="577" measuredH="181" mockupW="171" mockupH="121">`

[test file.zip](https://github.com/louisameline/Balsamiq-to-html/files/1880421/test.file.zip)